### PR TITLE
Disposed Texture Menu fix

### DIFF
--- a/TerrariaFortress.cs
+++ b/TerrariaFortress.cs
@@ -232,8 +232,11 @@ namespace TerrariaFortress
                 On.Terraria.Main.DrawMenu += Main_DrawMenu;
 
                 Main.soundMenuTick = GetSound("Sounds/Custom/UIHover1");
+                Main.soundInstanceMenuTick = Main.soundMenuTick.CreateInstance();
                 Main.soundMenuOpen = GetSound("Sounds/Custom/UIClickFull1");
+                Main.soundInstanceMenuOpen = Main.soundMenuOpen.CreateInstance();
                 Main.soundMenuClose = GetSound("Sounds/Custom/UIClickFull1");
+                Main.soundInstanceMenuClose = Main.soundMenuClose.CreateInstance();
             }
         }
 
@@ -242,15 +245,11 @@ namespace TerrariaFortress
             if (!Main.dedServ)
             {
                 Main.soundMenuTick = cachedTickSound;
+                Main.soundInstanceMenuTick = Main.soundMenuTick?.CreateInstance();
                 Main.soundMenuOpen = cachedOpenedSound;
+                Main.soundInstanceMenuOpen = Main.soundMenuOpen?.CreateInstance();
                 Main.soundMenuClose = cachedClosedSound;
-
-                cachedTickSound?.Dispose();
-                cachedTickSound = null;
-                cachedOpenedSound?.Dispose();
-                cachedOpenedSound = null;
-                cachedClosedSound?.Dispose();
-                cachedClosedSound = null;
+                Main.soundInstanceMenuClose = Main.soundMenuClose?.CreateInstance();
 
                 On.Terraria.Main.DrawMenu -= Main_DrawMenu;
 
@@ -373,24 +372,21 @@ namespace TerrariaFortress
                 }
             }
 
-			if (!changelogsOpened)
-			{
-				Main.logoTexture = TFUtils.UITextures.Logo;
-				Main.logo2Texture = TFUtils.UITextures.Logo;
-			}
+            if (!changelogsOpened)
+            {
+                Main.logoTexture = TFUtils.UITextures.Logo;
+                Main.logo2Texture = TFUtils.UITextures.Logo;
+            }
 
-			try
-			{
-				orig(self, gameTime);
-			}
-			finally
-			{
-				Main.logoTexture = cachedLogo;
-				Main.logo2Texture = cachedLogo2;
-
-                //cachedLogo.Dispose();
-                //cachedLogo2.Dispose();
-			}
+            try
+            {
+                orig(self, gameTime);
+            }
+            finally
+            {
+                Main.logoTexture = cachedLogo;
+                Main.logo2Texture = cachedLogo2;
+            }
         }
 
         public static readonly Color[] TFColor =

--- a/TerrariaFortress.cs
+++ b/TerrariaFortress.cs
@@ -32,10 +32,38 @@ namespace TerrariaFortress
         public struct UITextures
         {
             public static TerrariaFortress mod => ModContent.GetInstance<TerrariaFortress>();
-            public static Texture2D Beige = mod.GetTexture("Extras/UI1");
-            public static Texture2D Tooltip = mod.GetTexture("Items/TFItemTooltipUI");
-            public static Texture2D White = mod.GetTexture("Extras/UI2");
-            public static Texture2D Logo = mod.GetTexture("Extras/Logo");
+            public static Texture2D Beige;
+            public static Texture2D Tooltip;
+            public static Texture2D White;
+            public static Texture2D Logo;
+            public static Texture2D Empty;
+
+            public static void Load()
+            {
+                Beige = mod.GetTexture("Extras/UI1");
+                Tooltip = mod.GetTexture("Items/TFItemTooltipUI");
+                White = mod.GetTexture("Extras/UI2");
+                Logo = mod.GetTexture("Extras/Logo");
+                Empty = mod.GetTexture("Extras/FUCK");
+            }
+
+            public static void Unload()
+            {
+                Beige?.Dispose();
+                Beige = null;
+
+                Tooltip?.Dispose();
+                Tooltip = null;
+
+                White?.Dispose();
+                White = null;
+
+                Logo?.Dispose();
+                Logo = null;
+
+                Empty?.Dispose();
+                Empty = null;
+            }
         }
 
         /// <summary>
@@ -186,37 +214,48 @@ namespace TerrariaFortress
     public class TerrariaFortress : Mod
     {
         public static TerrariaFortress mod => ModContent.GetInstance<TerrariaFortress>();
-        public static Texture2D oldLogo1;
-        public static Texture2D oldLogo2;
         public SoundEffect cachedTickSound;
         public SoundEffect cachedOpenedSound;
         public SoundEffect cachedClosedSound;
 
         public override void Load()
         {
-            TFUtils.downloads = TFUtils.GetDownloadCount();
-            oldLogo1 = Main.logoTexture;
-            oldLogo2 = Main.logo2Texture;
-            cachedTickSound = Main.soundMenuTick;
-            cachedOpenedSound = Main.soundMenuOpen;
-            cachedClosedSound = Main.soundMenuClose;
+            if (!Main.dedServ)
+            {
+                TFUtils.downloads = TFUtils.GetDownloadCount();
+                cachedTickSound = Main.soundMenuTick;
+                cachedOpenedSound = Main.soundMenuOpen;
+                cachedClosedSound = Main.soundMenuClose;
 
-            On.Terraria.Main.DrawMenu += Main_DrawMenu;
+                TFUtils.UITextures.Load();
 
-            Main.logoTexture = TFUtils.UITextures.Logo;
-            Main.logo2Texture = TFUtils.UITextures.Logo;
-            Main.soundMenuTick = GetSound("Sounds/Custom/UIHover1");
-            Main.soundMenuOpen = GetSound("Sounds/Custom/UIClickFull1");
-            Main.soundMenuClose = GetSound("Sounds/Custom/UIClickFull1");
+                On.Terraria.Main.DrawMenu += Main_DrawMenu;
+
+                Main.soundMenuTick = GetSound("Sounds/Custom/UIHover1");
+                Main.soundMenuOpen = GetSound("Sounds/Custom/UIClickFull1");
+                Main.soundMenuClose = GetSound("Sounds/Custom/UIClickFull1");
+            }
         }
 
         public override void Unload()
         {
-            Main.logoTexture = oldLogo1;
-            Main.logo2Texture = oldLogo2;
-            Main.soundMenuTick = cachedTickSound;
-            Main.soundMenuOpen = cachedOpenedSound;
-            Main.soundMenuClose = cachedClosedSound;
+            if (!Main.dedServ)
+            {
+                Main.soundMenuTick = cachedTickSound;
+                Main.soundMenuOpen = cachedOpenedSound;
+                Main.soundMenuClose = cachedClosedSound;
+
+                cachedTickSound?.Dispose();
+                cachedTickSound = null;
+                cachedOpenedSound?.Dispose();
+                cachedOpenedSound = null;
+                cachedClosedSound?.Dispose();
+                cachedClosedSound = null;
+
+                On.Terraria.Main.DrawMenu -= Main_DrawMenu;
+
+                TFUtils.UITextures.Unload();
+            }
         }
 
         internal static string changelogsString;
@@ -225,8 +264,12 @@ namespace TerrariaFortress
         internal static bool changelogsHovering;
         internal static Rectangle changelogsBox;
         internal static Color hoverColor;
+
         private void Main_DrawMenu(On.Terraria.Main.orig_DrawMenu orig, Main self, GameTime gameTime)
         {
+            Texture2D cachedLogo = Main.logoTexture;
+            Texture2D cachedLogo2 = Main.logo2Texture;
+
             if (Main.gameMenu)
             {
                 if (Main.menuMode == 0 || Main.menuMode == -5)
@@ -256,8 +299,8 @@ namespace TerrariaFortress
                     }
                     else
                     {
-                        Main.logoTexture = GetTexture("Extras/FUCK");
-                        Main.logo2Texture = GetTexture("Extras/FUCK");
+                        Main.logoTexture = TFUtils.UITextures.Empty;
+                        Main.logo2Texture = TFUtils.UITextures.Empty;
                         changelogsString += "Close Terraria Fortress Changelogs";
                         #region The Actual Fucking Log
                         changelogsStringMessage =
@@ -328,9 +371,26 @@ namespace TerrariaFortress
                     TFUtils.DrawBackground(TFUtils.UITextures.Tooltip, new Vector2((int)changelogsPosition.X, changelogsBox.Y), new Vector2((int)letsFuckingMeasure.X, (int)letsFuckingMeasure.Y - 4), new Vector2(18f, 6f), changelogsHovering ? Color.White : new Color(255, 110, 110));
                     ChatManager.DrawColorCodedStringWithShadow(spriteBatch, changelogsFont, changelogsString, new Vector2(changelogsPosition.X, changelogsBox.Y), hoverColor, 0f, Vector2.Zero, changelogsScale);
                 }
-
-                orig(self, gameTime);
             }
+
+			if (!changelogsOpened)
+			{
+				Main.logoTexture = TFUtils.UITextures.Logo;
+				Main.logo2Texture = TFUtils.UITextures.Logo;
+			}
+
+			try
+			{
+				orig(self, gameTime);
+			}
+			finally
+			{
+				Main.logoTexture = cachedLogo;
+				Main.logo2Texture = cachedLogo2;
+
+                //cachedLogo.Dispose();
+                //cachedLogo2.Dispose();
+			}
         }
 
         public static readonly Color[] TFColor =

--- a/TerrariaFortress.csproj
+++ b/TerrariaFortress.csproj
@@ -6,6 +6,7 @@
     <TargetFramework>net45</TargetFramework>
     <PlatformTarget>x86</PlatformTarget>
     <LangVersion>8.0</LangVersion>
+    <OutputType>Library</OutputType>
   </PropertyGroup>
   <Target Name="BuildMod" AfterTargets="Build">
     <Exec Command="&quot;$(tMLBuildServerPath)&quot; -build $(ProjectDir) -eac $(TargetPath) -define &quot;$(DefineConstants)&quot; -unsafe $(AllowUnsafeBlocks)" />


### PR DESCRIPTION
(Hopefully) fixes the issue where reloading the mod would cause a System.ObjectDisposedException.

Changes:
- Added Load() and Unload() methods to TerrariaFortress.TFUtils.UITextures.
- Added the empty textured used in Main_DrawMenu() to TerrariaFortress.TFUtils.UITextures under the name "Empty".
- Instead of caching and restoring the default logo, the logo is now swapped out in Main_DrawMenu. Because of this, TerrariaFortress.oldLogo1 and TerrariaFortress.oldLogo2 were deleted.
- All code in Load() and Unload() is now wrapped in a dedServ check - Nothing loaded is used on servers.
- Unsubscribed from Main.DrawMenu in Unload().
- Updated Main's menu tick, open, and close SoundEffectInstances.